### PR TITLE
quote underscores?

### DIFF
--- a/R/day.R
+++ b/R/day.R
@@ -35,7 +35,7 @@ day_start <- function(date = Sys.Date(), path = "./") {
     lubridate::day() |>
     stringr::str_pad(width = 2, pad = "0") |>
     stringr::str_c("_", title, "/") |>
-    fs::path(path, ... = _) |>
+    fs::path(path, ... = "_") |>
     fs::path_norm() |>
     fs::dir_create()
 

--- a/R/puzzle.R
+++ b/R/puzzle.R
@@ -81,10 +81,10 @@ puzzle_fetch_text <- function(part, date) {
 
   # Format text
   temp |>
-    stringr::str_c("cat ", ... = _) |>
+    stringr::str_c("cat ", ... = "_") |>
     stringr::str_c(" | pandoc --from html --to markdown_strict") |>
     base::system(intern = TRUE) |>
-    stringr::str_c("# ", ... = _) |>
+    stringr::str_c("# ", ... = "_") |>
     stringr::str_replace("## ---", "---") |>
     stringr::str_remove(" $") |>
     stringr::str_replace_all("\\\\\\[", "[") |>


### PR DESCRIPTION
Attempt to install from github failed with:

```
Error in parse(outFile) : 
  /private/var/folders/3v/9bfvrwnn0gn50mfplb8xcchr0000gn/T/RtmphKCtp0/R.INSTALL9e12c47547e/aor/R/day.R:38:26: unexpected input
37:     stringr::str_c("_", title, "/") |>
38:     fs::path(path, ... = _
                             ^
```

Quoting the underscores got me through.